### PR TITLE
Client / 로그인전에도 build중인 덱 정보를 임시저장 가능하도록 수정

### DIFF
--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -4,18 +4,23 @@ import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import axios from 'axios';
 
-import { updateUserInfo } from '../actions';
+import { updateUserInfo, saveDeck } from '../actions';
 import AuthButton from '../components/Login/AuthButton';
 import Modal from '../components/Login/Modal';
 import { makeGoogleOAuthRequestURL } from '../utils/url';
+import { saveState, loadState } from '../utils/localStorage';
 
 const Login = () => {
   const userInfo = useSelector(state => state.userInfoReducer);
+  const { deck } = useSelector(state => state.deckReducer);
   const [modalShow, setModalShow] = useState(false);
   const dispatch = useDispatch();
   const history = useHistory();
 
   useEffect(() => {
+    if (deck.some(champ => champ.name)) {
+      saveState(deck);
+    }
     const getUserInfo = async accessToken => {
       try {
         const {
@@ -34,6 +39,11 @@ const Login = () => {
         }
 
         dispatch(updateUserInfo({ id, email, picture, riotId, isRegistered }));
+        const localStorageDeck = loadState();
+        if (localStorageDeck.some(champ => champ.name)) {
+          dispatch(saveDeck(localStorageDeck));
+          saveState([]);
+        }
         if (!isRegistered || !riotId) {
           setModalShow(true);
         } else {

--- a/client/src/utils/gameHelper.js
+++ b/client/src/utils/gameHelper.js
@@ -48,24 +48,17 @@ const calcTraitsScore = traits => {
     for (const { style, min, max } of sets) {
       if (max) {
         if (cnt >= min && cnt <= max) {
-          return acc + scoreMapper[style];
+          return acc + cnt;
         }
       } else {
         // only min
         if (cnt >= min) {
-          return acc + scoreMapper[style];
+          return acc + min;
         }
       }
     }
     return acc;
   }, 0);
-};
-
-const scoreMapper = {
-  bronze: 1,
-  silver: 3,
-  gold: 5,
-  chromatic: 7,
 };
 
 const levelCostMapper = {

--- a/client/src/utils/localStorage.js
+++ b/client/src/utils/localStorage.js
@@ -1,0 +1,19 @@
+export const saveState = state => {
+  try {
+    localStorage.setItem('appState', JSON.stringify(state));
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+export const loadState = () => {
+  try {
+    const appState = localStorage.getItem('appState');
+    if (appState) {
+      return JSON.parse(appState);
+    }
+  } catch (err) {
+    console.log(err);
+    return null;
+  }
+};


### PR DESCRIPTION
## 개요
- 비로그인/로그인 후 deck 정보가 그대로 남아있도록 수정
- 챔프 추천에 사용되는 점수 계산방식 수정

## 작업사항
- 로그인전 빌드중인 deck 정보를 localstorage에 저장하여, 로그인 이후에도 유지되도록 수정
- chromatic trait 중 단일 특성인 경우 1점으로 계산되도록 수정
- 점수 계산시 trait의 min을 고려해서 점수가 더해지도록 수정
